### PR TITLE
Auto switch to equivalent assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The options for the male character base would look like this:
 - `excluded-by` (optional) a list of tags. If it includes any tags on selected items then this item will not appear as an option
 - `palettes` (optional) the palette-definitions key for each palette used by the image. If it is left blank then the item will not be recolorable. List multiple palettes if the item has multiple recolorable pieces (a shirt with stripes, helmet with a feather, etc.)
 - `z_position` (optional) overrides the category's default z position
+- `label` (optional) the label for the item in the option picker. Defaults to the name of the item. If a selection is made incompatible with the spritesheet (e.g. by switching from the male to female body) a compatible item with the same label will automatically activate if one is available in the same category. Both the label and item name will be included in the attribution.
 - `authors` (required) a list of everyone who contributed to creating this item
 - `licenses` (required) a list of every license the authors applied to the item
 - `links` (required) a list of links to the item's source. It should include at least a link to the item's Open Game Art page

--- a/javascript/AssetCategory.js
+++ b/javascript/AssetCategory.js
@@ -86,6 +86,7 @@ export default class AssetCategory {
     this.urlParameterController.setURLParameters({ name: this.name, value: option.name })
 
     if (redrawSpritesheet) {
+      this.optionController.fixExcludedOptions(this)
       this.optionController.update()
       this.spritesheetController.update()
       this.attributionController.update()
@@ -275,5 +276,24 @@ export default class AssetCategory {
     ]
 
     return colorOffsets.map(([start, end]) => parseInt(hexCode.slice(start, end), 16))
+  }
+
+  /**
+   * Finds and sets a valid option if the selection is invalid. This will pick
+   * an option with the same label as the previous selection if one is
+   * available, otherwise it will use the first valid option ("none" in most
+   * cases).
+   */
+  fixExcludedOptions() {
+    const tags = this.allCategoryTags()
+    const selectedOption = this.selectedOption
+
+    if (selectedOption.isAvailable(tags)) return
+
+    const label = selectedOption.label
+    const availableOptions = this.availableOptions()
+    const newOption = availableOptions.find(option => option.label === label) ?? availableOptions[0]
+
+    this.setSelectedOption(newOption, false)
   }
 }

--- a/javascript/AssetOption.js
+++ b/javascript/AssetOption.js
@@ -14,7 +14,7 @@ export default class AssetOption {
     this.category = category
 
     this.default = optionData.default ?? false
-    this.label = optionData.label
+    this.label = optionData.label ?? name
     this.tags = optionData.tags ?? []
     this.excludedBy = optionData['excluded-by'] ?? []
     this.palettes = optionData.palettes ?? []

--- a/javascript/AssetOption.js
+++ b/javascript/AssetOption.js
@@ -14,6 +14,7 @@ export default class AssetOption {
     this.category = category
 
     this.default = optionData.default ?? false
+    this.label = optionData.label
     this.tags = optionData.tags ?? []
     this.excludedBy = optionData['excluded-by'] ?? []
     this.palettes = optionData.palettes ?? []
@@ -64,7 +65,7 @@ export default class AssetOption {
     if (this.icon) label.appendChild(this.icon)
 
     const labelText = document.createElement('span')
-    labelText.textContent = name
+    labelText.textContent = this.label ?? name
     label.appendChild(labelText)
 
     return buttonContainer

--- a/javascript/Attribution.js
+++ b/javascript/Attribution.js
@@ -9,7 +9,7 @@ export default class Attribution {
    */
   constructor(asset, assetData) {
     this.assetName = asset.name
-    this.assetLabel = asset.label ?? asset.name
+    this.assetLabel = asset.label
     this.categoryName = asset.category.name
     this.authors = assetData.authors ?? []
     this.licenses = assetData.licenses ?? []

--- a/javascript/Attribution.js
+++ b/javascript/Attribution.js
@@ -9,6 +9,7 @@ export default class Attribution {
    */
   constructor(asset, assetData) {
     this.assetName = asset.name
+    this.assetLabel = asset.label ?? asset.name
     this.categoryName = asset.category.name
     this.authors = assetData.authors ?? []
     this.licenses = assetData.licenses ?? []
@@ -51,7 +52,9 @@ export default class Attribution {
     const authorList = this.authors.join(', ')
     const licenseList = this.licenses.join(', ')
 
-    return `${this.categoryName}: ${this.assetName} by ${authorList}. Licenses: ${licenseList}.`
+    const labelAndName = this.assetLabel === this.assetName ? this.assetLabel : `${this.assetLabel} (${this.assetName})`
+
+    return `${this.categoryName}: ${labelAndName} by ${authorList}. Licenses: ${licenseList}.`
   }
 
   /**

--- a/javascript/OptionController.js
+++ b/javascript/OptionController.js
@@ -117,4 +117,18 @@ export default class OptionController {
     this.spritesheetController.update()
     this.attributionController.update()
   }
+
+  /**
+   * Attempts to find valid equivilent options for any that have been excluded
+   * by other selections. This is called when an option is selected.
+   *
+   * @param {AssetCategory} changedCategory the category that just updated
+   */
+  fixExcludedOptions(changedCategory) {
+    this.categories.forEach(category => {
+      if (category === changedCategory) return
+
+      category.fixExcludedOptions()
+    })
+  }
 }

--- a/javascript/SpritesheetElement.js
+++ b/javascript/SpritesheetElement.js
@@ -91,6 +91,8 @@ export default class SpritesheetElement {
   }
 
   frameSizeForAnimation(animationName) {
+    if (!this.animations) return 64
+
     const animation = this.animations.find(animation => animation.name === animationName)
     return animation.frameSize
   }

--- a/resources/sheet-definitions.json
+++ b/resources/sheet-definitions.json
@@ -438,6 +438,7 @@
 
   "pants": {
     "male": {
+      "label": "basic",
       "tags": [],
       "excluded-by": [
         "female",
@@ -461,6 +462,7 @@
       ]
     },
     "female": {
+      "label": "basic",
       "tags": [],
       "excluded-by": [
         "male",

--- a/resources/sheet-definitions.json
+++ b/resources/sheet-definitions.json
@@ -492,6 +492,7 @@
 
   "cape": {
     "solid-male": {
+      "label": "cape",
       "tags": [],
       "excluded-by": [
         "child",
@@ -521,6 +522,7 @@
       ]
     },
     "solid-female": {
+      "label": "cape",
       "tags": [],
       "excluded-by": [
         "child",


### PR DESCRIPTION
Add system to automatically switch to equivalent assets when the previous selection becomes incompatible with the spritesheet. This fixes the issue with the pants not updating to the correct version when the body is changed.